### PR TITLE
Small change but fixes exception revealed during porting to VS2015

### DIFF
--- a/xrCore/OPFuncs/op_engine_version.cpp
+++ b/xrCore/OPFuncs/op_engine_version.cpp
@@ -6,20 +6,20 @@
 namespace OPFuncs
 {
 
-	XRCORE_API std::string GetOPEngineVersion()
+	XRCORE_API LPCSTR GetOPEngineVersion()
 	{
+		static string1024 engineVersion="";
+		if (engineVersion[0] == 0)
+		{
 #ifdef PATCH_INFO_PRESENT
-		string512 patchVersion="";
-		sprintf_s(patchVersion," %s ver %s.%s",PATCH_DESCRIPTION , PATCH_MINOR , PATCH_MAJOR);
-#endif
-		string1024 engineVersion="";
-		sprintf_s(engineVersion,"%s ver %s.%s%s %s",ENGINE_DESCRIPTION,ENGINE_MINOR,ENGINE_MAJOR,
-#ifdef PATCH_INFO_PRESENT
-			patchVersion
+			sprintf_s(engineVersion,"%s ver %s.%s %s ver %s.%s %s"
+				,ENGINE_DESCRIPTION, ENGINE_MINOR, ENGINE_MAJOR
+				,PATCH_DESCRIPTION, PATCH_MINOR, PATCH_MAJOR
+				,ENGINE_BUILD_TYPE);
 #else
-			""
+			sprintf_s(engineVersion,"%s ver %s.%s %s",ENGINE_DESCRIPTION,ENGINE_MINOR,ENGINE_MAJOR,ENGINE_BUILD_TYPE);
 #endif
-			,ENGINE_BUILD_TYPE);
-		return std::string(engineVersion);
+		}
+		return engineVersion;
 	}
 }

--- a/xrCore/OPFuncs/op_engine_version.h
+++ b/xrCore/OPFuncs/op_engine_version.h
@@ -5,7 +5,7 @@
 
 namespace OPFuncs
 {
-	XRCORE_API std::string GetOPEngineVersion();
+	XRCORE_API LPCSTR GetOPEngineVersion();
 }
 
 #endif

--- a/xrCore/xrCore.cpp
+++ b/xrCore/xrCore.cpp
@@ -118,7 +118,7 @@ void xrCore::_initialize	(LPCSTR _ApplicationName, LogCallback cb, BOOL init_fs,
 		FS._initialize		(flags,0,fs_fname);
 
 		Msg					("'%s' build %d, %s","xrCore",build_id, build_date);
-		Msg					("%s\n",OPFuncs::GetOPEngineVersion().c_str());
+		Msg					("%s\n",OPFuncs::GetOPEngineVersion());
 		EFS._initialize		();
 #ifdef DEBUG
 	#ifndef	_EDITOR

--- a/xr_3da/xrGame/OPFuncs/lua_functions.cpp
+++ b/xr_3da/xrGame/OPFuncs/lua_functions.cpp
@@ -45,10 +45,7 @@ namespace OPFuncs
 
 	LPCSTR lua_GetOPEngineVersion()
 	{
-		std::string version=GetOPEngineVersion();
-		char* result=new char[version.length()+1];
-		strcpy(result,version.c_str());
-		return result;
+		return GetOPEngineVersion();
 	}
 
 	bool lua_IsOPEngine()


### PR DESCRIPTION
Fixed possible STL exception caused by passing std::string through exported function.
Fixed "memory leak" because allocated memory was not deallocated till the end of the game.