### PR TITLE
RU and UA charsets are supported now

### DIFF
--- a/xr_3da/xrGame/ui/UICustomEdit.h
+++ b/xr_3da/xrGame/ui/UICustomEdit.h
@@ -47,6 +47,7 @@ protected:
 
 	bool m_bInputFocus;
 	bool m_bShift;
+	bool m_bControl;
 
 	bool m_bNumbersOnly;
 	bool m_bFloatNumbers;


### PR DESCRIPTION
RU and UA charsets are supported in all edit boxes utilizing UICustomEdit. To select input charset use CTRL+E for English, CTRL+R for Russian and CTRL+U for Ukrainian