### PR TITLE
Input language symbol shown on the right side of edit box

### DIFF
--- a/xr_3da/xrGame/RegistryFuncs.cpp
+++ b/xr_3da/xrGame/RegistryFuncs.cpp
@@ -12,11 +12,10 @@
 #endif
 
 
-bool	ReadRegistryValue(LPCSTR rKeyName, DWORD rKeyType, void* value )
+bool	ReadRegistryValue(HKEY hBase, LPCSTR rPath, LPCSTR rKeyName, DWORD rKeyType, void* value )
 {	
-	HKEY hKey = 0;	
-	long res = RegOpenKeyEx(REGISTRY_BASE, 
-		REGISTRY_PATH, 0, KEY_READ, &hKey);
+	HKEY hKey = 0;
+	long res = RegOpenKeyEx(hBase, rPath, 0, KEY_READ, &hKey);
 
 	if (res != ERROR_SUCCESS)
 	{
@@ -107,7 +106,12 @@ bool	WriteRegistryValue	(LPCSTR rKeyName, DWORD rKeyType, const void* value)
 
 void	ReadRegistry_StrValue	(LPCSTR rKeyName, char* value )
 {
-	ReadRegistryValue(rKeyName, REG_SZ, value);
+	ReadRegistryValue(REGISTRY_BASE, REGISTRY_PATH, rKeyName, REG_SZ, value);
+}
+
+void	ReadRegistry_StrValue	(bool localMachine, LPCSTR rPath, LPCSTR rKeyName, char* value )
+{
+	ReadRegistryValue(localMachine ? HKEY_LOCAL_MACHINE : HKEY_CURRENT_USER, rPath, rKeyName, REG_SZ, value);
 }
 
 void	WriteRegistry_StrValue	(LPCSTR rKeyName, const char* value )
@@ -117,8 +121,14 @@ void	WriteRegistry_StrValue	(LPCSTR rKeyName, const char* value )
 
 void	ReadRegistry_DWValue	(LPCSTR rKeyName, DWORD& value )
 {
-	ReadRegistryValue(rKeyName, REG_DWORD, &value);
+	ReadRegistryValue(REGISTRY_BASE, REGISTRY_PATH, rKeyName, REG_DWORD, &value);
 }
+
+void	ReadRegistry_DWValue	(bool localMachine, LPCSTR rPath, LPCSTR rKeyName, DWORD& value )
+{
+	ReadRegistryValue(localMachine ? HKEY_LOCAL_MACHINE : HKEY_CURRENT_USER, rPath, rKeyName, REG_DWORD, &value);
+}
+
 void	WriteRegistry_DWValue	(LPCSTR rKeyName, const DWORD& value )
 {
 	WriteRegistryValue(rKeyName, REG_DWORD, &value);

--- a/xr_3da/xrGame/RegistryFuncs.h
+++ b/xr_3da/xrGame/RegistryFuncs.h
@@ -1,7 +1,9 @@
 #pragma once
 
 void	ReadRegistry_StrValue	(LPCSTR rKeyName, char* value );
+void	ReadRegistry_StrValue	(bool localMachine, LPCSTR rPath, LPCSTR rKeyName, char* value );
 void	WriteRegistry_StrValue	(LPCSTR rKeyName, const char* value );
 
 void	ReadRegistry_DWValue	(LPCSTR rKeyName, DWORD& value );
+void	ReadRegistry_DWValue	(bool localMachine, LPCSTR rPath, LPCSTR rKeyName, DWORD& value );
 void	WriteRegistry_DWValue	(LPCSTR rKeyName, const DWORD& value );

--- a/xr_3da/xrGame/ui/UICustomEdit.h
+++ b/xr_3da/xrGame/ui/UICustomEdit.h
@@ -2,6 +2,7 @@
 
 #include "UILines.h"
 #include "UIWindow.h"
+#include "UIStatic.h"
 
 class CUICustomEdit : public CUIWindow, public CUILinesOwner {
 	u32				m_max_symb_count;
@@ -38,16 +39,20 @@ public:
 			void	SetLightAnim			(LPCSTR lanim);
 
 protected:
-
 	bool KeyPressed(int dik);
 	bool KeyReleased(int dik);
 
 	void AddLetter(char c);
 	virtual void AddChar(char c);
-
+	
+	void CheckSwitchInputLanguage();
+	void ChangeInputLanguage();
+protected:
 	bool m_bInputFocus;
 	bool m_bShift;
 	bool m_bControl;
+	bool m_bAlt;
+	bool m_bCapital;
 
 	bool m_bNumbersOnly;
 	bool m_bFloatNumbers;
@@ -61,5 +66,8 @@ protected:
 
 //	u32	m_cursorColor;
 
-	CLAItem*				m_lanim;
+	CLAItem*	m_lanim;
+
+	CUIStatic m_languageIcon;
+	size_t m_currentSelectedLanguage;
 };


### PR DESCRIPTION
Input language can be switched by the same keyboard shortcut as in Windows (CTRL+SHIFT or ALT+SHIFT).

By default, only EN, RU and UA input languages are enabled (if installed). Comment ENRUUA_ONLY if all installed languages must be enabled. WARNING: only symbols for language set as language for non-unicode programs will be shown, thus, it is not recommended.
Language setting can be set per edit box or globally. By default it is per edit box. To enable global settings uncomment define USE_GLOBAL_LANGUAGE in UICustomEdit.cpp